### PR TITLE
test: disable coverage in watch mode or when NO_COVERAGE env is present

### DIFF
--- a/config/helpers.js
+++ b/config/helpers.js
@@ -22,7 +22,16 @@ function isWebpackDevServer() {
 
 var root = path.join.bind(path, ROOT);
 
+function useCoverage() {
+  if (EVENT.indexOf('--auto-watch') !== -1) {
+    return false;
+  } else {
+    return !process.env.hasOwnProperty('NO_COVERAGE')
+  }
+}
+
 exports.hasProcessFlag = hasProcessFlag;
 exports.hasNpmFlag = hasNpmFlag;
 exports.isWebpackDevServer = isWebpackDevServer;
 exports.root = root;
+exports.useCoverage = useCoverage;

--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -2,6 +2,25 @@
  * @author: @AngularClass
  */
 
+const helpers = require('./helpers');
+
+/**
+ * This object is the diff required to add coverage support to karma.
+ * Every property set here will OVERWRITE the property in the original config, no merges.
+ */
+const COVERAGE_CONFIG_DIFF = {
+  preprocessors: { './config/spec-bundle.js': ['coverage', 'webpack', 'sourcemap'] },
+  reporters: ['mocha', 'coverage', 'remap-coverage'],
+  coverageReporter: {
+    type: 'in-memory'
+  },
+  remapCoverageReporter: {
+    'text-summary': null,
+    json: './coverage/coverage.json',
+    html: './coverage/html'
+  }
+};
+
 module.exports = function (config) {
   var testWebpackConfig = require('./webpack.test.js')({ env: 'test' });
 
@@ -45,20 +64,10 @@ module.exports = function (config) {
      * preprocess matching files before serving them to the browser
      * available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
      */
-    preprocessors: { './config/spec-bundle.js': ['coverage', 'webpack', 'sourcemap'] },
+    preprocessors: { './config/spec-bundle.js': ['webpack', 'sourcemap'] },
 
     // Webpack Config at ./webpack.test.js
     webpack: testWebpackConfig,
-
-    coverageReporter: {
-      type: 'in-memory'
-    },
-
-    remapCoverageReporter: {
-      'text-summary': null,
-      json: './coverage/coverage.json',
-      html: './coverage/html'
-    },
 
     // Webpack please don't spam the console when running in karma!
     webpackMiddleware: {
@@ -67,7 +76,7 @@ module.exports = function (config) {
       noInfo: true,
       // and use stats to turn off verbose output
       stats: {
-        // options i.e. 
+        // options i.e.
         chunks: false
       }
     },
@@ -78,7 +87,7 @@ module.exports = function (config) {
      * possible values: 'dots', 'progress'
      * available reporters: https://npmjs.org/browse/keyword/karma-reporter
      */
-    reporters: ['mocha', 'coverage', 'remap-coverage'],
+    reporters: ['mocha'],
 
     // web server port
     port: 9876,
@@ -121,6 +130,11 @@ module.exports = function (config) {
     configuration.browsers = [
       'ChromeTravisCi'
     ];
+  }
+
+  // add coverage
+  if (helpers.useCoverage()) {
+    Object.assign(configuration, COVERAGE_CONFIG_DIFF);
   }
 
   config.set(configuration);

--- a/config/webpack.test.js
+++ b/config/webpack.test.js
@@ -5,6 +5,8 @@
 const helpers = require('./helpers');
 const path = require('path');
 
+const webpackMerge = require('webpack-merge'); // used to merge webpack configs
+
 /**
  * Webpack Plugins
  */
@@ -18,13 +20,37 @@ const ContextReplacementPlugin = require('webpack/lib/ContextReplacementPlugin')
  */
 const ENV = process.env.ENV = process.env.NODE_ENV = 'test';
 
+const USE_COVERAGE = helpers.useCoverage();
+const COVERAGE_CONFIG_DIFF = {
+  module: {
+    rules: [
+      /**
+       * Instruments JS files with Istanbul for subsequent code coverage reporting.
+       * Instrument only testing sources.
+       *
+       * See: https://github.com/deepsweet/istanbul-instrumenter-loader
+       */
+      {
+        enforce: 'post',
+        test: /\.(js|ts)$/,
+        loader: 'istanbul-instrumenter-loader',
+        include: helpers.root('src'),
+        exclude: [
+          /\.(e2e|spec)\.ts$/,
+          /node_modules/
+        ]
+      }
+    ]
+  }
+};
+
 /**
  * Webpack configuration
  *
  * See: http://webpack.github.io/docs/configuration.html#cli
  */
 module.exports = function (options) {
-  return {
+  const config = {
 
     /**
      * Source map for Karma from the help of karma-sourcemap-loader &  karma-webpack
@@ -96,8 +122,8 @@ module.exports = function (options) {
               loader: 'awesome-typescript-loader',
               query: {
                 // use inline sourcemaps for "karma-remap-coverage" reporter
-                sourceMap: false,
-                inlineSourceMap: true,
+                sourceMap: !USE_COVERAGE,
+                inlineSourceMap: USE_COVERAGE,
                 compilerOptions: {
 
                   // Remove TypeScript helpers to be injected
@@ -146,23 +172,6 @@ module.exports = function (options) {
           loader: 'raw-loader',
           exclude: [helpers.root('src/index.html')]
         },
-
-        /**
-         * Instruments JS files with Istanbul for subsequent code coverage reporting.
-         * Instrument only testing sources.
-         *
-         * See: https://github.com/deepsweet/istanbul-instrumenter-loader
-         */
-        {
-          enforce: 'post',
-          test: /\.(js|ts)$/,
-          loader: 'istanbul-instrumenter-loader',
-          include: helpers.root('src'),
-          exclude: [
-            /\.(e2e|spec)\.ts$/,
-            /node_modules/
-          ]
-        }
 
       ]
     },
@@ -249,4 +258,6 @@ module.exports = function (options) {
     }
 
   };
-}
+
+  return USE_COVERAGE ? webpackMerge(COVERAGE_CONFIG_DIFF, config) : config;
+};


### PR DESCRIPTION
NO_COVERAGE is provide for IDE integration

This PR enables proper breaking point in TS code.

Fixes #1392

Approach:
All configurations files (karma/webpack.test) are configured without coverage, if coverage support is needed it will be added into the config's.
This is common sense, there's no point in setting something then removing it which is also not clear and readable.

Coverage is opt-out, i.e. by default you will get coverage reports... the developer needs to opt out of coverage explicitly.

There are 2 ways to opt out:
  - Using `--watch-mode`. watch mode implies development session so no coverage there. This is automatically set as part of the npm scripts in this project.

  - Using `NO_COVERAGE` environment variable, when set the coverage will not run. This is a fallback that is useful for IDE integration where karama is executed and controlled by the IDE.

![image](https://cloud.githubusercontent.com/assets/5377501/22733664/72be0e8a-edfb-11e6-9475-efdaa3ca91d7.png)
