### PR TITLE
refactor(package.json): run clean task at the time of build

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   "homepage": "https://github.com/angularclass/angular2-webpack-starter",
   "license": "MIT",
   "scripts": {
-    "build:aot:prod": "npm run clean:dist && npm run clean:aot && webpack --config config/webpack.prod.js  --progress --profile --bail",
+    "build:aot:prod": "npm run clean && npm install && webpack --config config/webpack.prod.js  --progress --profile --bail",
     "build:aot": "npm run build:aot:prod",
-    "build:dev": "npm run clean:dist && webpack --config config/webpack.dev.js --progress --profile",
+    "build:dev": "npm run clean && npm install && webpack --config config/webpack.dev.js --progress --profile",
     "build:docker": "npm run build:prod && docker build -t angular2-webpack-start:latest .",
     "build:prod": "npm run clean:dist && webpack --config config/webpack.prod.js  --progress --profile --bail",
     "build": "npm run build:dev",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Run clean task at the time for build both for dev and production.


* **What is the current behavior?** (You can also link to an open issue here)
While running `build` task, it does not remove `compiled` directory which consist of Angular`s ngFactory files. Which through compile error even while building for development environment.
It is always good to freshly install dependencies on production to avoid such issues.

![error](https://cloud.githubusercontent.com/assets/2920003/22930266/69854948-f2e5-11e6-9c25-0a56e074cc4f.png)



* **What is the new behavior (if this is a feature change)?**
It will freshly install all the dependencies and create `dll` and `compile` files. Which avoids unexpected error during build time.


* **Other information**:
Now when you run `npm run build` or `npm run build:aot`

1. Clean task will run which will remove `node_modules doc coverage dist compiled dll`.
2. And `npm install` will run which will install all the dependencies and pass webpack config for build.