### PR TITLE
aligned require statements; semicolons; fix global variable isProd

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -9,17 +9,17 @@ const helpers = require('./helpers');
  * Webpack Plugins
  */
 // problem with copy-webpack-plugin
-const AssetsPlugin = require('assets-webpack-plugin');
+const AssetsPlugin                  = require('assets-webpack-plugin');
 const NormalModuleReplacementPlugin = require('webpack/lib/NormalModuleReplacementPlugin');
-const ContextReplacementPlugin = require('webpack/lib/ContextReplacementPlugin');
-const CommonsChunkPlugin = require('webpack/lib/optimize/CommonsChunkPlugin');
-const CopyWebpackPlugin = require('copy-webpack-plugin');
-const CheckerPlugin = require('awesome-typescript-loader').CheckerPlugin;
-const HtmlElementsPlugin = require('./html-elements-plugin');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
-const LoaderOptionsPlugin = require('webpack/lib/LoaderOptionsPlugin');
-const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin');
-const ngcWebpack = require('ngc-webpack');
+const ContextReplacementPlugin      = require('webpack/lib/ContextReplacementPlugin');
+const CommonsChunkPlugin            = require('webpack/lib/optimize/CommonsChunkPlugin');
+const CopyWebpackPlugin             = require('copy-webpack-plugin');
+const CheckerPlugin                 = require('awesome-typescript-loader').CheckerPlugin;
+const HtmlElementsPlugin            = require('./html-elements-plugin');
+const HtmlWebpackPlugin             = require('html-webpack-plugin');
+const LoaderOptionsPlugin           = require('webpack/lib/LoaderOptionsPlugin');
+const ScriptExtHtmlWebpackPlugin    = require('script-ext-html-webpack-plugin');
+const ngcWebpack                    = require('ngc-webpack');
 
 /*
  * Webpack Constants
@@ -38,7 +38,7 @@ const METADATA = {
  * See: http://webpack.github.io/docs/configuration.html#cli
  */
 module.exports = function (options) {
-  isProd = options.env === 'production';
+  let isProd = options.env === 'production';
   return {
 
     /*
@@ -279,11 +279,11 @@ module.exports = function (options) {
        * See: https://github.com/ampedandwired/html-webpack-plugin
        */
       new HtmlWebpackPlugin({
-        template: 'src/index.html',
-        title: METADATA.title,
+        template:       'src/index.html',
+        title:          METADATA.title,
         chunksSortMode: 'dependency',
-        metadata: METADATA,
-        inject: 'head'
+        metadata:       METADATA,
+        inject:         'head'
       }),
 
       /*
@@ -373,7 +373,7 @@ module.exports = function (options) {
       module: false,
       clearImmediate: false,
       setImmediate: false
-    }
+    },
 
   };
-}
+};

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -38,7 +38,7 @@ const METADATA = {
  * See: http://webpack.github.io/docs/configuration.html#cli
  */
 module.exports = function (options) {
-  let isProd = options.env === 'production';
+  var isProd = options.env === 'production';
   return {
 
     /*

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -2,17 +2,17 @@
  * @author: @AngularClass
  */
 
-const helpers = require('./helpers');
-const webpackMerge = require('webpack-merge'); // used to merge webpack configs
+const helpers         = require('./helpers');
+const webpackMerge    = require('webpack-merge'); // used to merge webpack configs
 const webpackMergeDll = webpackMerge.strategy({plugins: 'replace'});
-const commonConfig = require('./webpack.common.js'); // the settings that are common to prod and dev
+const commonConfig    = require('./webpack.common.js'); // the settings that are common to prod and dev
 
 /**
  * Webpack Plugins
  */
-const AddAssetHtmlPlugin = require('add-asset-html-webpack-plugin');
-const DefinePlugin = require('webpack/lib/DefinePlugin');
-const NamedModulesPlugin = require('webpack/lib/NamedModulesPlugin');
+const AddAssetHtmlPlugin  = require('add-asset-html-webpack-plugin');
+const DefinePlugin        = require('webpack/lib/DefinePlugin');
+const NamedModulesPlugin  = require('webpack/lib/NamedModulesPlugin');
 const LoaderOptionsPlugin = require('webpack/lib/LoaderOptionsPlugin');
 
 /**
@@ -21,7 +21,7 @@ const LoaderOptionsPlugin = require('webpack/lib/LoaderOptionsPlugin');
 const ENV = process.env.ENV = process.env.NODE_ENV = 'development';
 const HOST = process.env.HOST || 'localhost';
 const PORT = process.env.PORT || 3000;
-const HMR = helpers.hasProcessFlag('hot');
+const HMR  = helpers.hasProcessFlag('hot');
 const METADATA = webpackMerge(commonConfig({env: ENV}).metadata, {
   host: HOST,
   port: PORT,
@@ -254,4 +254,4 @@ module.exports = function (options) {
     }
 
   });
-}
+};

--- a/config/webpack.github-deploy.js
+++ b/config/webpack.github-deploy.js
@@ -1,18 +1,18 @@
 /**
  * @author: @AngularClass
  */
-const fs = require('fs');
-const path = require('path');
-const helpers = require('./helpers');
-const ghDeploy = require('./github-deploy');
+const fs           = require('fs');
+const path         = require('path');
+const helpers      = require('./helpers');
+const ghDeploy     = require('./github-deploy');
 const webpackMerge = require('webpack-merge'); // used to merge webpack configs
 
 /**
  * Webpack Constants
  */
 const GIT_REMOTE_NAME = 'origin';
-const COMMIT_MESSAGE = 'Updates';
-const GH_REPO_NAME = ghDeploy.getRepoName(GIT_REMOTE_NAME);
+const COMMIT_MESSAGE  = 'Updates';
+const GH_REPO_NAME    = ghDeploy.getRepoName(GIT_REMOTE_NAME);
 
 module.exports = function (options) {
   const webpackConfigFactory = ghDeploy.getWebpackConfigModule(options); // the settings that are common to prod and dev

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -2,21 +2,21 @@
  * @author: @AngularClass
  */
 
-const helpers = require('./helpers');
+const helpers      = require('./helpers');
 const webpackMerge = require('webpack-merge'); // used to merge webpack configs
 const commonConfig = require('./webpack.common.js'); // the settings that are common to prod and dev
 
 /**
  * Webpack Plugins
  */
-const DefinePlugin = require('webpack/lib/DefinePlugin');
-const ExtractTextPlugin = require('extract-text-webpack-plugin');
-const IgnorePlugin = require('webpack/lib/IgnorePlugin');
-const LoaderOptionsPlugin = require('webpack/lib/LoaderOptionsPlugin');
+const DefinePlugin                  = require('webpack/lib/DefinePlugin');
+const ExtractTextPlugin             = require('extract-text-webpack-plugin');
+const IgnorePlugin                  = require('webpack/lib/IgnorePlugin');
+const LoaderOptionsPlugin           = require('webpack/lib/LoaderOptionsPlugin');
 const NormalModuleReplacementPlugin = require('webpack/lib/NormalModuleReplacementPlugin');
-const ProvidePlugin = require('webpack/lib/ProvidePlugin');
-const UglifyJsPlugin = require('webpack/lib/optimize/UglifyJsPlugin');
-const OptimizeJsPlugin = require('optimize-js-plugin');
+const ProvidePlugin                 = require('webpack/lib/ProvidePlugin');
+const UglifyJsPlugin                = require('webpack/lib/optimize/UglifyJsPlugin');
+const OptimizeJsPlugin              = require('optimize-js-plugin');
 
 /**
  * Webpack Constants
@@ -330,4 +330,4 @@ module.exports = function (env) {
     }
 
   });
-}
+};

--- a/config/webpack.test.js
+++ b/config/webpack.test.js
@@ -7,9 +7,9 @@ const helpers = require('./helpers');
 /**
  * Webpack Plugins
  */
-const ProvidePlugin = require('webpack/lib/ProvidePlugin');
-const DefinePlugin = require('webpack/lib/DefinePlugin');
-const LoaderOptionsPlugin = require('webpack/lib/LoaderOptionsPlugin');
+const ProvidePlugin            = require('webpack/lib/ProvidePlugin');
+const DefinePlugin             = require('webpack/lib/DefinePlugin');
+const LoaderOptionsPlugin      = require('webpack/lib/LoaderOptionsPlugin');
 const ContextReplacementPlugin = require('webpack/lib/ContextReplacementPlugin');
 
 /**
@@ -259,4 +259,4 @@ module.exports = function (options) {
     }
 
   };
-}
+};


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix: global `isProd` variable in `webpack.common.js`
coding style fix:
- added semicolons at the end of some `.config.js` files
- align `require()` and some other statements