### PR TITLE
Updated readme for Material2 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,8 +355,6 @@ import * as _ from 'lodash';
  * We are using inline source-maps and hot module replacement which will increase the bundle size.
 * If you're in China
  * check out https://github.com/cnpm/cnpm
-* If you're looking to add Angular 2 Material Design
- * check out the [material2](https://github.com/AngularClass/angular2-webpack-starter/tree/material2) branch
 * node-pre-gyp ERR in npm install (Windows)
  * install Python x86 version between 2.5 and 3.0 on windows see issue [#626](https://github.com/AngularClass/angular2-webpack-starter/issues/626)
 * `Error:Error: Parse tsconfig error [{"messageText":"Unknown compiler option 'lib'.","category":1,"code":5023},{"messageText":"Unknown compiler option 'strictNullChecks'.","category":1,"code":5023},{"messageText":"Unknown compiler option 'baseUrl'.","category":1,"code":5023},{"messageText":"Unknown compiler option 'paths'.","category":1,"code":5023},{"messageText":"Unknown compiler option 'types'.","category":1,"code":5023}]`

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ This seed repo serves as an Angular 2 starter for anyone looking to get up and r
 * End-to-end Angular 2 code using Protractor.
 * Type manager with @types
 * Hot Module Replacement with Webpack and [@angularclass/hmr](https://github.com/angularclass/angular2-hmr) and [@angularclass/hmr-loader](https://github.com/angularclass/angular2-hmr-loader)
-* Material Design with [angular/material2](https://github.com/angular/material2)
 * Angular 4 support via changing package.json and any future Angular versions
 
 ### Quick start


### PR DESCRIPTION
#1414 says Material2 branch has been closed. So I have updated the readme for that.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Docs Update for Readme.md


* **What is the current behavior?** (You can also link to an open issue here)
Links to wrong material2 branch results in 404 on Github.


* **What is the new behavior (if this is a feature change)?**
The link is removed no branch is present in the repo, so no reference to material2.


* **Other information**:
