### PR TITLE
add vars from external config files

### DIFF
--- a/config/vars/common.js
+++ b/config/vars/common.js
@@ -1,0 +1,4 @@
+module.exports = {
+  GA_CODE: 'UA-91111111-1',
+  HOME_TOKEN: '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI',
+}

--- a/config/vars/development.js
+++ b/config/vars/development.js
@@ -1,0 +1,4 @@
+module.exports = {
+  GA_CODE: 'UA-91111111-2',
+  HOME_TOKEN: '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI',
+}

--- a/config/vars/index.js
+++ b/config/vars/index.js
@@ -1,0 +1,10 @@
+const commonConfig = require('./common');
+
+module.exports = function (env, prefix) {
+  prefix = prefix || 'VARS';
+  prefix = prefix + '.';
+  const _ = Object.assign({}, commonConfig, require(`./${env}`));
+  const config = {};
+  Object.keys(_).map(function (k) {config[prefix +k] = JSON.stringify(_[k]);});
+  return config;
+}

--- a/config/vars/production.js
+++ b/config/vars/production.js
@@ -1,0 +1,4 @@
+module.exports = {
+  GA_CODE: 'UA-91111111-2',
+  HOME_TOKEN: '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI',
+}

--- a/config/vars/test.js
+++ b/config/vars/test.js
@@ -1,0 +1,4 @@
+module.exports = {
+  GA_CODE: 'UA-91111111-2',
+  HOME_TOKEN: '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI',
+}

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -22,6 +22,7 @@ const ENV = process.env.ENV = process.env.NODE_ENV = 'development';
 const HOST = process.env.HOST || 'localhost';
 const PORT = process.env.PORT || 3000;
 const HMR = helpers.hasProcessFlag('hot');
+const VARS = require('./vars')(ENV); // the project VARS
 const METADATA = webpackMerge(commonConfig({env: ENV}).metadata, {
   host: HOST,
   port: PORT,
@@ -143,7 +144,7 @@ module.exports = function (options) {
        * See: https://webpack.github.io/docs/list-of-plugins.html#defineplugin
        */
       // NOTE: when adding more properties, make sure you include them in custom-typings.d.ts
-      new DefinePlugin({
+      new DefinePlugin(Object.assign({
         'ENV': JSON.stringify(METADATA.ENV),
         'HMR': METADATA.HMR,
         'process.env': {
@@ -151,7 +152,7 @@ module.exports = function (options) {
           'NODE_ENV': JSON.stringify(METADATA.ENV),
           'HMR': METADATA.HMR,
         }
-      }),
+      }, VARS)),
 
       new DllBundlesPlugin({
         bundles: {

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -24,6 +24,7 @@ const OptimizeJsPlugin = require('optimize-js-plugin');
 const ENV = process.env.NODE_ENV = process.env.ENV = 'production';
 const HOST = process.env.HOST || 'localhost';
 const PORT = process.env.PORT || 8080;
+const VARS = require('./vars')(ENV); // the project VARS
 const METADATA = webpackMerge(commonConfig({
   env: ENV
 }).metadata, {
@@ -154,7 +155,7 @@ module.exports = function (env) {
        * See: https://webpack.github.io/docs/list-of-plugins.html#defineplugin
        */
       // NOTE: when adding more properties make sure you include them in custom-typings.d.ts
-      new DefinePlugin({
+      new DefinePlugin(Object.assign({
         'ENV': JSON.stringify(METADATA.ENV),
         'HMR': METADATA.HMR,
         'process.env': {
@@ -162,7 +163,7 @@ module.exports = function (env) {
           'NODE_ENV': JSON.stringify(METADATA.ENV),
           'HMR': METADATA.HMR,
         }
-      }),
+      }, VARS)),
 
       /**
        * Plugin: UglifyJsPlugin

--- a/config/webpack.test.js
+++ b/config/webpack.test.js
@@ -16,6 +16,7 @@ const ContextReplacementPlugin = require('webpack/lib/ContextReplacementPlugin')
  * Webpack Constants
  */
 const ENV = process.env.ENV = process.env.NODE_ENV = 'test';
+const VARS = require('./vars')(ENV); // the project VARS
 
 /**
  * Webpack configuration
@@ -194,7 +195,7 @@ module.exports = function (options) {
        * See: https://webpack.github.io/docs/list-of-plugins.html#defineplugin
        */
       // NOTE: when adding more properties make sure you include them in custom-typings.d.ts
-      new DefinePlugin({
+      new DefinePlugin(Object.assign({
         'ENV': JSON.stringify(ENV),
         'HMR': false,
         'process.env': {
@@ -202,7 +203,7 @@ module.exports = function (options) {
           'NODE_ENV': JSON.stringify(ENV),
           'HMR': false,
         }
-      }),
+      }, VARS)),
 
       /**
        * Plugin: ContextReplacementPlugin

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -31,6 +31,7 @@ export class HomeComponent implements OnInit {
   ) {}
 
   public ngOnInit() {
+    console.log('HOME_TOKEN in env vars: ' + VARS.HOME_TOKEN);
     console.log('hello `Home` component');
     // this.title.getData().subscribe(data => this.data = data);
   }

--- a/src/custom-typings.d.ts
+++ b/src/custom-typings.d.ts
@@ -61,6 +61,9 @@ declare var ENV: string;
 declare var HMR: boolean;
 declare var System: SystemJS;
 
+// only work for DefinePlugin
+declare var VARS: any;
+
 interface SystemJS {
   import: (path?: string) => Promise<any>;
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature
Help it easier to add new variables in code and different environments, make use of the webpack DefinePlugin


* **What is the current behavior?** (You can also link to an open issue here)
Consider my case: 
When I want to add a new config, like `Google Analytics token`, they should be different in development/test/production mode. (I think it would be better to add it into DefinePlugin)
So first I add `GA_TOKEN` to each `webpack.*.js`'s DefinePlugin: 
```
      new DefinePlugin({
        'ENV': JSON.stringify(METADATA.ENV),
        'HMR': METADATA.HMR,
+        'GA_TOKEN': 'this is a setting in dev',
        'process.env': {
          'ENV': JSON.stringify(METADATA.ENV),
          'NODE_ENV': JSON.stringify(METADATA.ENV),
          'HMR': METADATA.HMR,
        }
      }),
```

And then add it into `custom-typings.d.ts`:
```
declare var GA_TOKEN: string;
```

Finally, I can use the GA_TOKEN in my ts code, like the ENV variable which already defined and declared.

When my settings getting growth, like `PAYMENT_TOKEN`, `BACKEND_SERVER`, thus coding style gets explosion.

* **What is the new behavior (if this is a feature change)?**

Just simply define a GA_TOKEN in the config/vars/development.js and config/vars/prod.js, and easily use `VARS.GA_TOKEN` in your ts code.
No other configs need to be changed.

* **Other information**:

While export all the config out into a single file, it would make it easier to be encrypt and generated
