### PR TITLE
 feat(webpack): ignoring mock-data dir when prod

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -267,7 +267,9 @@ module.exports = function (options) {
       new CopyWebpackPlugin([
         { from: 'src/assets', to: 'assets' },
         { from: 'src/meta'}
-      ]),
+      ],
+        isProd ? { ignore: [ 'mock-data/**/*' ] } : undefined
+      ),
 
 
       /*


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
feature


* **What is the current behavior?**
mock-data files being copy in prod build


* **What is the new behavior (if this is a feature change)?**
mock-data files not being copy in prod build

I discovered it's very useful to use mock-data files both in development and test, but it's bit annoying when publishing to prod, these files usually unnecessary.