### PR TITLE
Added 'IS_PROD' flag

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -146,6 +146,7 @@ module.exports = function (options) {
       new DefinePlugin({
         'ENV': JSON.stringify(METADATA.ENV),
         'HMR': METADATA.HMR,
+		'IS_PROD': false,
         'process.env': {
           'ENV': JSON.stringify(METADATA.ENV),
           'NODE_ENV': JSON.stringify(METADATA.ENV),

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -157,6 +157,7 @@ module.exports = function (env) {
       new DefinePlugin({
         'ENV': JSON.stringify(METADATA.ENV),
         'HMR': METADATA.HMR,
+		'IS_PROD': true,
         'process.env': {
           'ENV': JSON.stringify(METADATA.ENV),
           'NODE_ENV': JSON.stringify(METADATA.ENV),

--- a/config/webpack.test.js
+++ b/config/webpack.test.js
@@ -197,6 +197,7 @@ module.exports = function (options) {
       new DefinePlugin({
         'ENV': JSON.stringify(ENV),
         'HMR': false,
+		'IS_PROD': false,
         'process.env': {
           'ENV': JSON.stringify(ENV),
           'NODE_ENV': JSON.stringify(ENV),

--- a/src/custom-typings.d.ts
+++ b/src/custom-typings.d.ts
@@ -60,6 +60,7 @@ declare module 'modern-lru' {
 declare var ENV: string;
 declare var HMR: boolean;
 declare var System: SystemJS;
+declare var IS_PROD: boolean;
 
 interface SystemJS {
   import: (path?: string) => Promise<any>;


### PR DESCRIPTION
Added 'IS_PROD' flag to indicate whether the running environment is production or not. Resolves #1700.

Now it's easier to run 'debug-only' or 'production-only' functionality in the TypeScript code just by checking this flag.