### PR TITLE
Fix npm cache clean for running on npm 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "clean:aot": "npm run rimraf -- compiled",
     "clean:dist": "npm run rimraf -- dist",
     "clean:install": "npm set progress=false && npm install",
-    "clean": "npm cache clean && npm run rimraf -- node_modules doc coverage dist compiled dll",
+    "clean": "npm cache clean --force && npm run rimraf -- node_modules doc coverage dist compiled dll",
     "docker": "docker",
     "docs": "npm run typedoc -- --options typedoc.json --exclude '**/*.spec.ts' ./src/",
     "e2e:live": "npm-run-all -p -r server:prod:ci protractor:live",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Now `npm run clean` sript fails in npm 5.


* **What is the new behavior (if this is a feature change)?**
This commit fixes npm 5 failing.


* **Other information**:
