### PR TITLE
Add ability to use Chrome headless mode in prod (instead of PhantomJS)

### DIFF
--- a/config/protractor.conf.js
+++ b/config/protractor.conf.js
@@ -33,6 +33,7 @@ exports.config = {
   capabilities: {
     'browserName': 'chrome',
     'chromeOptions': {
+      //'args': ["--headless", "--disable-gpu", "--window-size=1280x800"]
       'args': ['show-fps-counter=true']
     }
   },

--- a/config/protractor.conf.js
+++ b/config/protractor.conf.js
@@ -33,7 +33,7 @@ exports.config = {
   capabilities: {
     'browserName': 'chrome',
     'chromeOptions': {
-      //'args': ["--headless", "--disable-gpu", "--window-size=1280x800"]
+      //'args': ["--headless", "--disable-gpu", "--window-size=1280x800",  "--no-sandbox"]
       'args': ['show-fps-counter=true']
     }
   },


### PR DESCRIPTION
from https://github.com/angular/protractor/blob/master/docs/browser-setup.md#using-headless-chrome

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

Chrome

* **What is the new behavior (if this is a feature change)?**

Chrome Headless

* **Other information**:

Add ability to use Chrome headless mode
