### PR TITLE
chore(config): remove json-loader as no longer needed

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -147,16 +147,6 @@ module.exports = function (options) {
         },
 
         /**
-         * Json loader support for *.json files.
-         *
-         * See: https://github.com/webpack/json-loader
-         */
-        {
-          test: /\.json$/,
-          use: 'json-loader'
-        },
-
-        /**
          * To string and css loader support for *.css files (from Angular components)
          * Returns file content as string
          *

--- a/config/webpack.test.js
+++ b/config/webpack.test.js
@@ -118,17 +118,6 @@ module.exports = function (options) {
         },
 
         /**
-         * Json loader support for *.json files.
-         *
-         * See: https://github.com/webpack/json-loader
-         */
-        {
-          test: /\.json$/,
-          loader: 'json-loader',
-          exclude: [helpers.root('src/index.html')]
-        },
-
-        /**
          * Raw loader support for *.css files
          * Returns file content as string
          *

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "inline-manifest-webpack-plugin": "^3.0.1",
     "istanbul-instrumenter-loader": "2.0.0",
     "jasmine-core": "^2.5.2",
-    "json-loader": "^0.5.4",
     "karma": "^1.6.0",
     "karma-chrome-launcher": "^2.0.0",
     "karma-coverage": "^1.1.1",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
It removes `json-loader` according to [official webpack guide](https://webpack.js.org/guides/migrating/#json-loader-is-not-required-anymore).


* **What is the current behavior?** (You can also link to an open issue here)
For `json-loader@0.5.6` it was throwing the following error several times in CLI and browser console:
![image](https://user-images.githubusercontent.com/8938562/28501033-94bb2ed2-6fd3-11e7-880a-440739292cfc.png)
Although was fixed in 0.5.7



* **What is the new behavior (if this is a feature change)?**
Behavior remains exactly the same, but the config is slighter.