### PR TITLE
add PUBLIC env var for webpack dev server's public property

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -21,10 +21,12 @@ const LoaderOptionsPlugin = require('webpack/lib/LoaderOptionsPlugin');
 const ENV = process.env.ENV = process.env.NODE_ENV = 'development';
 const HOST = process.env.HOST || 'localhost';
 const PORT = process.env.PORT || 3000;
+const PUBLIC = process.env.PUBLIC || undefined;
 const HMR = helpers.hasProcessFlag('hot');
 const METADATA = webpackMerge(commonConfig({env: ENV}).metadata, {
   host: HOST,
   port: PORT,
+  public: PUBLIC,
   ENV: ENV,
   HMR: HMR
 });
@@ -220,6 +222,7 @@ module.exports = function (options) {
     devServer: {
       port: METADATA.port,
       host: METADATA.host,
+      public: METADATA.public,
       historyApiFallback: true,
       watchOptions: {
         // if you're using Docker you may need this


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Allow's overriding webpack dev server public property. I use it in my case where in eclipse che it assigns an ephemeral port, and my dev machine is another one on the network, 10.0.0.1 (or dev in /etc/hosts) not 127.0.0.1. I can then inject with a macro ie `PUBLIC=dev:${server.3000.port} npm run start`

* **What is the current behavior?** (You can also link to an open issue here)

It's always port 3000 and HOST doesn't give us hostname choice, just bind ip

* **What is the new behavior (if this is a feature change)?**

Defaults to undefined and causes no change. It allows above.

* **Other information**:
