### PR TITLE
chore: upgrade ngc-webpack to 3.2.0 and remove resourceOverride

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -383,29 +383,6 @@ module.exports = function (options) {
          */
         disabled: !AOT,
         tsConfig: helpers.root('tsconfig.webpack.json'),
-        /**
-         * A path to a file (resource) that will replace all resource referenced in @Components.
-         * For each `@Component` the AOT compiler compiles it creates new representation for the templates (html, styles)
-         * of that `@Components`. It means that there is no need for the source templates, they take a lot of
-         * space and they will be replaced by the content of this resource.
-         *
-         * To leave the template as is set to a falsy value (the default).
-         *
-         * TIP: Use an empty file as an overriding resource. It is recommended to use a ".js" file which
-         * usually has small amount of loaders hence less performance impact.
-         *
-         * > This feature is doing NormalModuleReplacementPlugin for AOT compiled resources.
-         *
-         * ### resourceOverride and assets
-         * If you reference assets in your styles/html that are not inlined and you expect a loader (e.g. url-loader)
-         * to copy them, don't use the `resourceOverride` feature as it does not support this feature at the moment.
-         * With `resourceOverride` the end result is that webpack will replace the asset with an href to the public
-         * assets folder but it will not copy the files. This happens because the replacement is done in the AOT compilation
-         * phase but in the bundling it won't happen (it's being replaced with and empty file...)
-         *
-         * @default undefined
-         */
-        resourceOverride: helpers.root('config/resource-override.js')
       }),
 
       /**

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^2.0.4",
     "ng-router-loader": "^2.1.0",
-    "ngc-webpack": "^3.1.0",
+    "ngc-webpack": "^3.2.0",
     "node-sass": "^4.5.2",
     "npm-run-all": "^4.0.2",
     "optimize-js-plugin": "0.0.4",


### PR DESCRIPTION
Now when with the AOT cleanup loader there is no need to use resourceOverride and it is not recommened for use as it produced some
side effects with assets.