### PR TITLE
change order of ScriptExtHtmlWebpackPlugin

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -310,20 +310,6 @@ module.exports = function (options) {
       //  include: 'asyncChunks'
       //}),
 
-      /**
-       * Plugin: ScriptExtHtmlWebpackPlugin
-       * Description: Enhances html-webpack-plugin functionality
-       * with different deployment options for your scripts including:
-       *
-       * See: https://github.com/numical/script-ext-html-webpack-plugin
-       */
-      new ScriptExtHtmlWebpackPlugin({
-        sync: /polyfill|vendor/,
-        defaultAttribute: 'async',
-        preload: [/polyfill|vendor|main/],
-        prefetch: [/chunk/]
-      }),
-
       /*
       * Plugin: HtmlWebpackPlugin
       * Description: Simplifies creation of HTML files to serve your webpack bundles.
@@ -338,6 +324,20 @@ module.exports = function (options) {
         chunksSortMode: 'dependency',
         metadata: METADATA,
         inject: 'body'
+      }),
+      
+       /**
+       * Plugin: ScriptExtHtmlWebpackPlugin
+       * Description: Enhances html-webpack-plugin functionality
+       * with different deployment options for your scripts including:
+       *
+       * See: https://github.com/numical/script-ext-html-webpack-plugin
+       */
+      new ScriptExtHtmlWebpackPlugin({
+        sync: /polyfills|vendor/,
+        defaultAttribute: 'async',
+        preload: [/polyfills|vendor|main/],
+        prefetch: [/chunk/]
       }),
 
       /**


### PR DESCRIPTION
this plugin must come after the HtmlWebpackPlugin just as the README of it suggests

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
the plugin is before the HtmlWebpackPlugin


* **What is the new behavior (if this is a feature change)?**
the plugin comes after the HtmlWebpackPlugin


* **Other information**:
the read me of the plugin has specified that this plugin must come **after** the HtmlWebpackPlugin and the order is important
