### PR TITLE
change env var from PUBLIC to PUBLIC_DEV #1859

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -21,7 +21,7 @@ const LoaderOptionsPlugin = require('webpack/lib/LoaderOptionsPlugin');
 const ENV = process.env.ENV = process.env.NODE_ENV = 'development';
 const HOST = process.env.HOST || 'localhost';
 const PORT = process.env.PORT || 3000;
-const PUBLIC = process.env.PUBLIC || undefined;
+const PUBLIC = process.env.PUBLIC_DEV || undefined;
 const HMR = helpers.hasProcessFlag('hot');
 const METADATA = webpackMerge(commonConfig({env: ENV}).metadata, {
   host: HOST,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

fixes #1859 

* **What is the current behavior?** (You can also link to an open issue here)

uses PUBLIC env var which conflicts with windows

* **What is the new behavior (if this is a feature change)?**

uses PUBLIC_DEV instead

* **Other information**:
